### PR TITLE
Add Home and End Combos. Remove BYT Keyboard.

### DIFF
--- a/croskeyboard3/croskeyboard3.cpp
+++ b/croskeyboard3/croskeyboard3.cpp
@@ -871,6 +871,14 @@ void CrosKeyboardChromebookLayout(PCROSKEYBOARD_CONTEXT pDevice,
 			else if (keyCode == 0x51) {
 				*overrideCtrl = true;
 				keyCodes[i] = 0x4e; //page down (down arrow)
+			}		
+			else if (keyCode == 0x50) {
+				*overrideCtrl = true;
+				keyCodes[i] = 0x4a; //home (left arrow)
+			}
+			else if (keyCode == 0x4f) {
+				*overrideCtrl = true;
+				keyCodes[i] = 0x4d; //end (right arrow)					
 			}
 		}
 		if (pDevice->RightCtrl) {
@@ -1076,6 +1084,14 @@ void CrosKeyboardMediaKeySwappedLayout(PCROSKEYBOARD_CONTEXT pDevice,
 			else if (keyCode == 0x51) {
 				*overrideCtrl = true;
 				keyCodes[i] = 0x4e; //page down (down arrow)
+			}		
+			else if (keyCode == 0x50) {
+				*overrideCtrl = true;
+				keyCodes[i] = 0x4a; //home (left arrow)
+			}
+			else if (keyCode == 0x4f) {
+				*overrideCtrl = true;
+				keyCodes[i] = 0x4d; //end (right arrow)					
 			}
 		}
 		if (pDevice->RightCtrl) {

--- a/croskeyboard3/croskeyboard3.cpp
+++ b/croskeyboard3/croskeyboard3.cpp
@@ -4,8 +4,6 @@
 static ULONG CrosKeyboardDebugLevel = 100;
 static ULONG CrosKeyboardDebugCatagories = DBG_INIT || DBG_PNP || DBG_IOCTL;
 
-#define POLL 0 //Enable for Bay Trail
-
 NTSTATUS
 DriverEntry(
 	__in PDRIVER_OBJECT  DriverObject,
@@ -1476,10 +1474,6 @@ BOOLEAN OnInterruptIsr(
 	if (!pDevice->ConnectInterrupt)
 		return true;
 
-#if POLL
-	return true;
-#endif
-
 	LARGE_INTEGER currentTime;
 	KeQuerySystemTime(&currentTime);
 
@@ -1528,14 +1522,6 @@ void CrosKeyboardTimerFunc(_In_ WDFTIMER hTimer) {
 	WDFDEVICE Device = (WDFDEVICE)WdfTimerGetParentObject(hTimer);
 	PCROSKEYBOARD_CONTEXT pDevice = GetDeviceContext(Device);
 
-#if POLL
-	unsigned char ps2code = __inbyte(0x60);
-	if (ps2code != pDevice->lastps2codeint) {
-		pDevice->lastps2codeint = ps2code;
-		pDevice->lastps2code = ps2code;
-		keyPressed(pDevice);
-	}
-#else
 	WDF_OBJECT_ATTRIBUTES attributes;
 	WDF_WORKITEM_CONFIG workitemConfig;
 	WDFWORKITEM hWorkItem;
@@ -1550,7 +1536,6 @@ void CrosKeyboardTimerFunc(_In_ WDFTIMER hTimer) {
 		&hWorkItem);
 
 	WdfWorkItemEnqueue(hWorkItem);
-#endif
 
 	return;
 }


### PR DESCRIPTION
Home and End Combos as requested by a user here:

https://www.reddit.com/r/chrultrabook/comments/5u596n/thought_mapping_backforward_to_homeend/

BYT keyboard is no longer needed since keyboard interrupts are working fine on current UEFI ROMs.

Compiled and tested on C720. Home and End combos working as intended. No issues removing BYT keyboard.

Now split into separate commits as part of one pull request.