### PR TITLE
Edited Polling Option for Clarity.

### DIFF
--- a/croskeyboard3/croskeyboard3.cpp
+++ b/croskeyboard3/croskeyboard3.cpp
@@ -4,7 +4,7 @@
 static ULONG CrosKeyboardDebugLevel = 100;
 static ULONG CrosKeyboardDebugCatagories = DBG_INIT || DBG_PNP || DBG_IOCTL;
 
-#define POLL 0 //Enable for Bay Trail
+#define POLL 0 //Enable for Polling
 
 NTSTATUS
 DriverEntry(


### PR DESCRIPTION
This option is no longer needed for BYT since keyboard interrupts are working fine on current BYT UEFI ROMs.

Edited the comment here for clarity. Not removing the poll compile option if it is useful for debugging a new platform.